### PR TITLE
Kernel: Use OmniROM repo

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,18 +1,16 @@
 # Bootloader
-TARGET_BOOTLOADER_BOARD_NAME := MSM8996
+TARGET_BOOTLOADER_BOARD_NAME := msm8996
 TARGET_NO_BOOTLOADER := true
 
 # Platform
 TARGET_BOARD_PLATFORM := msm8996
 TARGET_BOARD_PLATFORM_GPU := qcom-adreno530
 
-TARGET_USES_64_BIT_BINDER := true
-
 # Architecture
 TARGET_ARCH := arm64
 TARGET_ARCH_VARIANT := armv8-a
-TARGET_CPU_ABI := armeabi-v8a
-TARGET_CPU_ABI2 := 
+TARGET_CPU_ABI := arm64-v8a
+TARGET_CPU_ABI2 :=
 TARGET_CPU_VARIANT := kryo
 
 TARGET_2ND_ARCH := arm
@@ -21,18 +19,28 @@ TARGET_2ND_CPU_ABI := armeabi-v7a
 TARGET_2ND_CPU_ABI2 := armeabi
 TARGET_2ND_CPU_VARIANT := cortex-a53
 
+ENABLE_CPUSETS := true
+TARGET_USES_INTERACTION_BOOST := true
+TARGET_USE_QCOM_BIONIC_OPTIMIZATION := true
+ENABLE_SCHEDBOOST := true
+TARGET_USES_QCOM_BSP := true
+TARGET_USES_64_BIT_BINDER := true
+
 # Kernel
-BOARD_KERNEL_CMDLINE := console=ttyHSL0,115200,n8 androidboot.console=ttyHSL0 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 cma=32M@0-0xffffffff androidboot.selinux=permissive
+BOARD_KERNEL_CMDLINE := console=ttyHSL0,115200,n8 androidboot.console=ttyHSL0 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 cma=32M@0-0xffffffff
+BOARD_KERNEL_TAGS_OFFSET := 0x02000000
+BOARD_RAMDISK_OFFSET     := 0x02200000
 BOARD_KERNEL_BASE := 0x80000000
 BOARD_KERNEL_PAGESIZE := 4096
-BOARD_MKBOOTIMG_ARGS := --kernel_offset 0x00008000 --ramdisk_offset 0x01000000 --tags_offset 0x00000100
 BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 TARGET_KERNEL_APPEND_DTB := true
 TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_HEADER_ARCH := arm64
 TARGET_KERNEL_SOURCE := kernel/leeco/msm8996
-TARGET_KERNEL_CONFIG := lineage_x2_defconfig
 TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
+TARGET_COMPILE_WITH_MSM_KERNEL := true
+
+TARGET_KERNEL_CONFIG := x2_defconfig
 
 # /proc/partitions * 2 * BLOCK_SIZE (512) = size in bytes
 BOARD_BOOTIMAGE_PARTITION_SIZE := 67108864

--- a/omni.dependencies
+++ b/omni.dependencies
@@ -7,8 +7,8 @@
   },
   {
     "remote":"github",
-    "repository": "LineageOS/android_kernel_leeco_msm8996",
+    "repository": "omnirom/android_kernel_leeco_msm8996/",
     "target_path": "kernel/leeco/msm8996",
-    "revision":"cm-14.1"
+    "revision":"android-7.1"
   }
 ]


### PR DESCRIPTION
Heyyo, I think the issue with TWRP-3.1.1.2-x2 builds is because "omni_x2.mk" uses Omni Repo for vendors yet this file's using LineageOS for kernel? I could be wrong but it makes more sense to pair OmniROM kernel with vendor.